### PR TITLE
Fixes #280

### DIFF
--- a/en-US/Design.xml
+++ b/en-US/Design.xml
@@ -642,12 +642,6 @@ $ vi myFile.txt
 
 				</formalpara>
 				 <itemizedlist>
-					<listitem>
-						<para>
-							<ulink url="https://uinames.com/">https://uinames.com/</ulink>
-						</para>
-
-					</listitem>
 					 <listitem>
 						<para>
 							<ulink url="http://listofrandomnames.com/">http://listofrandomnames.com/</ulink>


### PR DESCRIPTION
uinames link no longer works.

We have two other options so I just removed this one. Subsection now appears as follows:
![Screenshot from 2021-08-16 12-09-26](https://user-images.githubusercontent.com/1518237/129502290-38499b05-5834-4f52-91d4-73c986b33c40.png)
