### PR TITLE
Fixes #409 and other required repairs.

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
-    <title>Stylepedia.net</title>
+    <title>Red Hat Style Guide</title>
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
     <meta name="description" content="Red Hat style guide emporium.">
     <meta name="keywords" content="Red Hat style guide emporium.">
@@ -43,29 +43,15 @@
       <p>
         The official style guide for Red&nbsp;Hat technical documentation, including how to write for translation, common mistakes to avoid, rules for everyday punctuation, and grammar.
       </p>
-      <p>
-        A dedicated guide to Docbook XML as used in Red&nbsp;Hat Training courses.
-      </p>
 
       <h3>
-      <a href="https://stylepedia.net/style/4.2" target="_blank" title="The Red&nbsp;Hat Technical Writing Style Guide">
-        <img class="social" src="font/fontawesome/svgs/brands/readme.svg" alt="Style Guide" width="40em" /> Red&nbsp;Hat Technical Writing Style Guide v4.2</a>
+      <a href="https://stylepedia.net/style/6.0" target="_blank" title="The Red&nbsp;Hat Technical Writing Style Guide">
+        <img class="social" src="font/fontawesome/svgs/brands/readme.svg" alt="Style Guide" width="40em" /> Red&nbsp;Hat Technical Writing Style Guide v6.0</a>
     </h3>
-
       <h3>
-      <a href="https://stylepedia.net/style/5.0" target="_blank" title="The Red&nbsp;Hat Technical Writing Style Guide">
-        <img class="social" src="font/fontawesome/svgs/brands/readme.svg" alt="Style Guide" width="40em" /> Red&nbsp;Hat Technical Writing Style Guide v5.0</a>
+      <a href="https://stylepedia.net/style/5.1" target="_blank" title="The Red&nbsp;Hat Technical Writing Style Guide">
+        <img class="social" src="font/fontawesome/svgs/brands/readme.svg" alt="Style Guide" width="40em" /> Red&nbsp;Hat Technical Writing Style Guide v5.1</a>
     </h3>
-
-    <!--<h3>
-      <a href="http://stylepedia.net/docbook/3.1" title="DocBook XML Guide v3.1">
-    <img class="social" src="font/fontawesome/svgs/solid/code.svg" alt="XML Guide" width="40em" /> RHT DocBook XML Guide v3.1</a>-->
-    </h3>
-
-      <h3>
-        <a href="https://stylepedia.net/docbook/4.0" title="DocBook XML Guide v4.0">
-          <img class="social" src="font/fontawesome/svgs/solid/code.svg" alt="XML Guide" width="40em" /> RHT DocBook XML Guide v4.0</a>
-      </h3>
 
     <h3>
       <a href="https://www.redhat.com/en/about/brand/standards" target="_blank">
@@ -77,7 +63,7 @@
   <footer>
     <div>
 
-    <p>Copyright ©2021 Red Hat</p>
+    <p>Copyright ©2022 Red Hat</p>
 
     <p>Powered by <strong>HTML5</strong></p>
     </div>


### PR DESCRIPTION
* Updated copyright year
* Updated versions on links to style guides
* Removed statement about providing DocBook guidance
