### PR TITLE
feat: Add advice on naming the default branch in an inclusive way.

### DIFF
--- a/en-US/Language.xml
+++ b/en-US/Language.xml
@@ -1018,7 +1018,8 @@
       Such use diminishes the horror of the dehumanizing practice of slavery.
       Use of "master" is acceptable in other contexts, such as to refer to mastery of a skill.
 			 The master and slave mount propagation terminology that is used in Linux is problematic and divisive, and needs to be changed. 
-			 When naming the default branch name for a GitHub repository, use "main" instead of "master.
+			 When naming the default branch name for a GitHub repository, use "main" instead of "master".
+			 Use of "master" is acceptable in other contexts, such as to refer to mastery of a skill.
 		</para>
 		 <para>
 			Avoid gender bias.

--- a/en-US/Language.xml
+++ b/en-US/Language.xml
@@ -1015,7 +1015,6 @@
 		</para>
 		 <para>
 			Do not use "master" when it is paired with "slave".
-      Such use diminishes the horror of the dehumanizing practice of slavery.
       Use of "master" is acceptable in other contexts, such as to refer to mastery of a skill.
 			 The master and slave mount propagation terminology that is used in Linux is problematic and divisive, and needs to be changed. 
 			 When naming the default branch name for a GitHub repository, use "main" instead of "master".

--- a/en-US/Language.xml
+++ b/en-US/Language.xml
@@ -1015,7 +1015,6 @@
 		</para>
 		 <para>
 			Do not use "master" when it is paired with "slave".
-      Use of "master" is acceptable in other contexts, such as to refer to mastery of a skill.
 			 The master and slave mount propagation terminology that is used in Linux is problematic and divisive, and needs to be changed. 
 			 When naming the default branch name for a GitHub repository, use "main" instead of "master".
 			 Use of "master" is acceptable in other contexts, such as to refer to mastery of a skill.

--- a/en-US/Language.xml
+++ b/en-US/Language.xml
@@ -1017,6 +1017,8 @@
 			Do not use "master" when it is paired with "slave".
       Such use diminishes the horror of the dehumanizing practice of slavery.
       Use of "master" is acceptable in other contexts, such as to refer to mastery of a skill.
+			 The master and slave mount propagation terminology that is used in Linux is problematic and divisive, and needs to be changed. 
+			 When naming the default branch name for a GitHub repository, use "main" instead of "master.
 		</para>
 		 <para>
 			Avoid gender bias.


### PR DESCRIPTION
## Changes made
I added information on how to use inclusive names when creating a default branch for a GitHub’s repository.

## Motivation
As a Black woman who frequents the open source community, seeing “master” as the central branch illicits images of slavery. This causes me and others black open source contributors to feel that our contributions are inferior, thus, causing us to lose interest in contributing to the project.

## Benefits 

Creates a more inclusive environment.

## Corresponding issue
- Fixes issue #489