### PR TITLE
Add 64-bit architecture guidance

### DIFF
--- a/en-US/0-9.xml
+++ b/en-US/0-9.xml
@@ -43,14 +43,14 @@
 			 <listitem>
 				<para>
 					<emphasis>n.</emphasis> A 64-bit version of the ARM architecture. 
-					This term can refer to both AArch66/aarch64 and to ARM64/arm64. 
+					This term can refer to both AArch66/`aarch64` and to ARM64/`arm64`. 
 				</para>
 				 <para>
-					Use this format in general cases when writing for both names of the architecture and various cloud providers.
+					Use this format in general cases to refer to names of the architecture for various cloud providers.
 				</para>
 				 <para>
-					Cloud providers can use different formats of this term when using architectures. 
-					If you are documenting code, commands, or outputs, confer with your subject-matter expert on the correct format for the specific use case.
+					Cloud providers might use different formats of this term to refer to architectures. 
+					If you are documenting code, commands, or outputs, then confer with your subject-matter expert on the correct format for the specific use case.
 				</para>
 				 <para>
 					Examples:
@@ -58,12 +58,12 @@
 				 <itemizedlist>
 					<listitem>
 						<para>
-							The customer is using Amazon Web Services (AWS) on 64-bit ARM systems.
+							Amazon Web Services (AWS) on 64-bit ARM systems
 						</para>
 					</listitem>
 					 <listitem>
 						<para>
-							The customer is using multiple machine types for Microsoft Azure on 64-bit ARM infrastructures.
+							Machine types for Microsoft Azure on 64-bit ARM infrastructures
 						</para>
 					</listitem>
 				 </itemizedlist>
@@ -80,11 +80,11 @@
 				<para>
 					<emphasis>n.</emphasis> A 64-bit version of the x86 architecture. 
 					This term is a synonym of x86_64. 
-					Use this format in general cases when writing for names of the architectures for various cloud providers.
+					Use this format in general cases to refer to names of the architecture for various cloud providers.
 				</para>
 				 <para>
-					Cloud providers can use different formats of this term when using architectures. 
-					If you are documenting code, commands or outputs, confer with your subject-matter expert on the correct format for the specific use case.
+					Cloud providers might use different formats of this term to refer to architectures. 
+					If you are documenting code, commands or outputs, then confer with your subject-matter expert on the correct format for the specific use case.
 				</para>
 				 <para>
 					Examples:

--- a/en-US/0-9.xml
+++ b/en-US/0-9.xml
@@ -38,6 +38,77 @@
 
 		</varlistentry>
 
+		 <varlistentry id="a64-bit">
+			<term role="true">64-bit ARM</term>
+			 <listitem>
+				<para>
+					<emphasis>n.</emphasis> A 64-bit version of the ARM architecture. 
+					This term can refer to both AArch66/aarch64 and to ARM64/arm64. 
+				</para>
+				 <para>
+					Use this format in general cases when writing for both names of the architecture and various cloud providers.
+				</para>
+				 <para>
+					Cloud providers can use different formats of this term when using architectures. 
+					If you are documenting code, commands, or outputs, confer with your subject-matter expert on the correct format for the specific use case.
+				</para>
+				 <para>
+					Examples:
+				</para>
+				 <itemizedlist>
+					<listitem>
+						<para>
+							The customer is using Amazon Web Services (AWS) on 64-bit ARM systems.
+						</para>
+					</listitem>
+					 <listitem>
+						<para>
+							The customer is using multiple machine types for Microsoft Azure on 64-bit ARM infrastructures.
+						</para>
+					</listitem>
+				 </itemizedlist>
+        <para>
+          Refer also to <xref linkend="a64-bit-x86"/>, <xref linkend="aarch64"/>, <xref linkend="AMD64"/>, <xref linkend="ARM64"/>, <xref linkend="Intel64"/>, and <xref linkend="x86-64"/>.
+        </para>
+
+			</listitem>
+
+		</varlistentry>
+		 <varlistentry id="a64-bit-x86">
+			<term role="true">64-bit x86</term>
+			 <listitem>
+				<para>
+					<emphasis>n.</emphasis> A 64-bit version of the x86 architecture. 
+					This term is a synonym of x86_64. 
+					Use this format in general cases when writing for names of the architectures for various cloud providers.
+				</para>
+				 <para>
+					Cloud providers can use different formats of this term when using architectures. 
+					If you are documenting code, commands or outputs, confer with your subject-matter expert on the correct format for the specific use case.
+				</para>
+				 <para>
+					Examples:
+				</para>
+				 <itemizedlist>
+					<listitem>
+						<para>
+							Amazon Web Services (AWS) on 64-bit x86 systems
+						</para>
+					</listitem>
+					 <listitem>
+						<para>
+							Machine types for Microsoft Azure on 64-bit x86 infrastructures
+						</para>
+					</listitem>
+				 </itemizedlist>
+        <para>
+          Refer also to <xref linkend="a64-bit"/>, <xref linkend="aarch64"/>, <xref linkend="AMD64"/>, <xref linkend="ARM64"/>, <xref linkend="Intel64"/>, and <xref linkend="x86-64"/>.
+        </para>
+
+			</listitem>
+
+		</varlistentry>
+
 	</variablelist>
 </chapter>
 

--- a/en-US/A.xml
+++ b/en-US/A.xml
@@ -103,20 +103,83 @@
 			</listitem>
 
 		</varlistentry>
-		 <varlistentry id="AMD64">
-			<term role="true">AMD64</term>
+		 <varlistentry id="aarch64">
+			<term role="true">AArch64, aarch64</term>
 			 <listitem>
 				<para>
-					Correct. Do not use "Hammer", "x86_64", "x86-64", "x64", "64-bit x86" or other variations as the name of this architecture.
+					<emphasis>n.</emphasis> A 64-bit version of the ARM architecture. 
+					Use this term when referring to operating systems and server instances, for example Red&nbsp;Hat Enterprise Linux, Fedora, CoreOS, and other Linux distributions. 
 				</para>
 				 <para>
-					The correct term for AMD's implementation of this architecture is "AMD64".
-          When discussing the architecture generally, reference both AMD64 and Intel 64 implementations specifically.
+					Use the uppercase (AArch64) format in general cases when referring to system architecture.
+					Use the lowercase (aarch64) format only when referring to objects or parameters. 
+					It can be styled as code (monospace font or a code-styled block) when referring to code.
 				</para>
+				 <para>
+					Cloud providers can use different formats of this term when using architectures. 
+					If you are documenting code, commands, or outputs, confer with your subject-matter expert on the correct format for the specific use case.
+				</para>
+				 <para>
+					Examples:
+				</para>
+				 <itemizedlist>
+					<listitem>
+						<para>
+							When running Red&nbsp;Hat Enterprise Linux with an AArch64 system, run the following commands:
+						</para>
+					</listitem>
+					 <listitem>
+						<para>
+							Specify the system architecture of your cluster, such as <code>x86_64</code> or <code>aarch64</code>.
+						</para>
+					</listitem>
+				 </itemizedlist>
         <para>
-          Refer also to <xref linkend="Intel64"/>.
+          Refer also to <xref linkend="a64-bit"/>, <xref linkend="a64-bit-x86"/>, <xref linkend="AMD64"/>, <xref linkend="ARM64"/>, <xref linkend="Intel64"/>, and <xref linkend="x86-64"/>.
         </para>
-				 <note>
+
+			</listitem>
+
+		</varlistentry>
+		 <varlistentry id="AMD64">
+			<term role="true">AMD64, amd64</term>
+			 <listitem>
+				<para>
+					<emphasis>n.</emphasis> The AMD 64-bit version of the x86 architecture. 
+					Use this term for Red&nbsp;Hat OpenShift Container Platform attributes, Kubernetes, operators, application programming interfaces (APIs), or command-line interface (CLI) objects. 
+				</para>
+				 <para>
+					Use the uppercase format (AMD64) in general sentences when referring to Red&nbsp;Hat OpenShift Container Platform features.
+					Use the lowercase format (amd64) only when referring to objects or parameters. 
+					It can be styled as code (monospace font or a code-styled block) when referring to code.
+				</para>
+				 <para>
+					Cloud providers can use different formats of this term when using architectures. 
+					If you are documenting code, commands, or outputs, confer with your subject-matter expert on the correct format for the specific use case.
+				</para>
+				 <para>
+					Examples:
+				</para>
+				 <itemizedlist>
+					<listitem>
+						<para>
+							This operator is supported on AMD64 and ARM64 platforms.
+						</para>
+					</listitem>
+					 <listitem>
+						<para>
+							In this scenario, <code>amd64</code> is a valid value for X.
+						</para>
+					</listitem>
+				 </itemizedlist>
+				 <!-- <para>
+					The correct term for AMD's implementation of this architecture is "AMD64".
+					When discussing the architecture generally, reference both AMD64 and Intel 64 implementations specifically.
+				</para> -->
+        <para>
+          Refer also to <xref linkend="a64-bit"/>, <xref linkend="a64-bit-x86"/>, <xref linkend="aarch64"/>, <xref linkend="ARM64"/>, <xref linkend="Intel64"/>, and <xref linkend="x86-64"/>.
+        </para>
+				 <!-- <note>
 					<para>
 						The AMD64 logo is trademarked; the term "AMD64" is not. For more information about AMD trademarks, refer to the <citetitle>AMD Trademark Information</citetitle> page at <ulink url="https://www.amd.com/en/corporate/trademarks" />.
 					</para>
@@ -124,11 +187,50 @@
 						For more information about Intel&reg; trademarks, refer to <ulink url="http://www.intel.com/content/www/us/en/legal/trademarks.html" /> and <ulink url="http://www.intel.com/content/www/us/en/trademarks/trademarks.html" />.
 					</para>
 
-				</note>
+				</note> -->
 
 			</listitem>
 
 		</varlistentry>
+		 <varlistentry id="ARM64">
+			<term role="true">ARM64, arm64</term>
+			 <listitem>
+				<para>
+					<emphasis>n.</emphasis> A 64-bit version of the ARM architecture. 
+					Use this term for Red&nbsp;Hat OpenShift Container Platform attributes, Kubernetes, operators, application programming interfaces (APIs), and command-line interface (CLI) objects. 
+				</para>
+				 <para>
+					Use the uppercase format (ARM64) in general sentences when referring to Red&nbsp;Hat OpenShift Container Platform features.
+					Use lowercase format (arm64) only when referring to objects or parameters. 
+					It can be styled as code (monospace font or a code-styled block) when referring to code.
+				</para>
+				 <para>
+					Cloud providers can use different formats of this term when using architectures. 
+					If you are documenting code, commands, or outputs, confer with your subject-matter expert on the correct format for the specific use case.
+				</para>
+				 <para>
+					Examples:
+				</para>
+				 <itemizedlist>
+					<listitem>
+						<para>
+							In this exercise, you create an ARM64 compute machine set.
+						</para>
+					</listitem>
+					 <listitem>
+						<para>
+							In this scenario, <code>arm64</code> is a valid value for X.
+						</para>
+					</listitem>
+				 </itemizedlist>
+        <para>
+          Refer also to <xref linkend="a64-bit"/>, <xref linkend="a64-bit-x86"/>, <xref linkend="aarch64"/>, <xref linkend="AMD64"/>, <xref linkend="Intel64"/>, and <xref linkend="x86-64"/>.
+        </para>
+
+			</listitem>
+
+		</varlistentry>
+
 		 <varlistentry id="andor">
 			<term role="false">and/or</term>
 			 <listitem>

--- a/en-US/A.xml
+++ b/en-US/A.xml
@@ -116,8 +116,8 @@
 					It can be styled as code (monospace font or a code-styled block) when referring to code.
 				</para>
 				 <para>
-					Cloud providers can use different formats of this term when using architectures. 
-					If you are documenting code, commands, or outputs, confer with your subject-matter expert on the correct format for the specific use case.
+					Cloud providers might use different formats of this term to refer to architectures. 
+					If you are documenting code, commands, or outputs, then confer with your subject-matter expert on the correct format for the specific use case.
 				</para>
 				 <para>
 					Examples:
@@ -154,8 +154,8 @@
 					It can be styled as code (monospace font or a code-styled block) when referring to code.
 				</para>
 				 <para>
-					Cloud providers can use different formats of this term when using architectures. 
-					If you are documenting code, commands, or outputs, confer with your subject-matter expert on the correct format for the specific use case.
+					Cloud providers might use different formats of this term to refer to architectures. 
+					If you are documenting code, commands, or outputs, then confer with your subject-matter expert on the correct format for the specific use case.
 				</para>
 				 <para>
 					Examples:
@@ -205,8 +205,8 @@
 					It can be styled as code (monospace font or a code-styled block) when referring to code.
 				</para>
 				 <para>
-					Cloud providers can use different formats of this term when using architectures. 
-					If you are documenting code, commands, or outputs, confer with your subject-matter expert on the correct format for the specific use case.
+					Cloud providers might use different formats of this term to refer to architectures. 
+					If you are documenting code, commands, or outputs, then confer with your subject-matter expert on the correct format for the specific use case.
 				</para>
 				 <para>
 					Examples:

--- a/en-US/I.xml
+++ b/en-US/I.xml
@@ -134,24 +134,41 @@
 			<term role="true">Intel 64</term>
 			 <listitem>
 				<para>
-					Correct.
+					<emphasis>n.</emphasis> The Intel 64-bit version of the x86 architecture. 
+					Use this format when referring to information that is exclusive to Intel processors. 
+					For Red&nbsp;Hat products, it applies only to Red&nbsp;Hat Enterprise Linux content. 
+				</para>
+				 <para>
+					Cloud providers can use different formats of this term when using architectures. 
+					If you are documenting code, commands, or outputs, confer with your subject-matter expert on the correct format for the specific use case.
+				</para>
+				 <para>
+					Example:
+				</para>
+				 <itemizedlist>
+					<listitem>
+						<para>
+							This feature can run on only Intel 64 processors.
+						</para>
+					</listitem>
+				 </itemizedlist>				
+				 <!-- <para>
           Do not use "Hammer", "x86_64", "x86-64", "x64", "64-bit x86", or other variations as the name of this architecture.
 				</para>
 				 <para>
 					The correct term for Intel's implementation of this architecture is "Intel&reg;&nbsp;64".
           When discussing the architecture generally, reference both AMD64 and Intel 64 implementations specifically.
-				</para>
+				</para> -->
         <para>
-          Refer also to <xref linkend="AMD64"/>.
+          Refer also to <xref linkend="a64-bit"/>, <xref linkend="a64-bit-x86"/>, <xref linkend="aarch64"/>, <xref linkend="AMD64"/>, <xref linkend="ARM64"/>, and <xref linkend="x86-64"/>.
         </para>
 				 <note>
-					<para>
+					<!-- <para>
 						The AMD64 logo is trademarked; the term "AMD64" is not.
             For more information about AMD trademarks, refer to the <citetitle>AMD Trademark Information</citetitle> page at <ulink url="https://www.amd.com/en/corporate/trademarks" />.
-					</para>
-<!-- Updated URL for AMD trademarks. -->					
+					</para> -->
 					 <para>
-						For more information about Intel&reg; trademarks, refer to <ulink url="http://www.intel.com/content/www/us/en/legal/trademarks.html" /> and <ulink url="http://www.intel.com/content/www/us/en/trademarks/trademarks.html" />.
+						For more information about Intel trademarks, refer to <ulink url="http://www.intel.com/content/www/us/en/legal/trademarks.html" /> and <ulink url="http://www.intel.com/content/www/us/en/trademarks/trademarks.html" />.
 					</para>
 
 				</note>

--- a/en-US/I.xml
+++ b/en-US/I.xml
@@ -136,11 +136,11 @@
 				<para>
 					<emphasis>n.</emphasis> The Intel 64-bit version of the x86 architecture. 
 					Use this format when referring to information that is exclusive to Intel processors. 
-					For Red&nbsp;Hat products, it applies only to Red&nbsp;Hat Enterprise Linux content. 
+					For Red&nbsp;Hat products, use only for Red&nbsp;Hat Enterprise Linux content. 
 				</para>
 				 <para>
-					Cloud providers can use different formats of this term when using architectures. 
-					If you are documenting code, commands, or outputs, confer with your subject-matter expert on the correct format for the specific use case.
+					Cloud providers might use different formats of this term to refer to architectures. 
+					If you are documenting code, commands, or outputs, then confer with your subject-matter expert on the correct format for the specific use case.
 				</para>
 				 <para>
 					Example:

--- a/en-US/XYZ.xml
+++ b/en-US/XYZ.xml
@@ -16,6 +16,41 @@
 			</listitem>
 
 		</varlistentry>
+		 <varlistentry id="x86-64">
+			<term role="true">x86_64</term>
+			 <listitem>
+				<para>
+					<emphasis>n.</emphasis> A 64-bit version of the x86 architecture. 
+					Use this term when referring to operating systems and server instances, for example Red&nbsp;Hat Enterprise Linux, Fedora, CoreOS and other Linux distributions. 
+					Use this format without backticks in general cases when referring to system architecture. 
+					Use this format in backticks when referring to architecture as a value or parameter. 
+				</para>
+				 <para>
+					Cloud providers can use different formats of this term when using architectures. 
+					If you are documenting code, commands or outputs, confer with your subject-matter expert on the correct format for the specific use case.
+				</para>
+				 <para>
+					Examples:
+				</para>
+				 <itemizedlist>
+					<listitem>
+						<para>
+							Specifies the type of architecture for your server, such as x86_64.
+						</para>
+					</listitem>
+					 <listitem>
+						<para>
+							When specifying the architecture, <code>x86_64</code> is a valid value.
+						</para>
+					</listitem>
+				 </itemizedlist>
+        <para>
+          Refer also to <xref linkend="a64-bit"/>, <xref linkend="a64-bit-x86"/>, <xref linkend="aarch64"/>, <xref linkend="AMD64"/>, <xref linkend="ARM64"/>, and <xref linkend="Intel64"/>.
+        </para>
+
+			</listitem>
+
+		</varlistentry>		
 		 <varlistentry id="xyxemacs">
 			<term>XEmacs</term>
 			 <listitem>

--- a/en-US/XYZ.xml
+++ b/en-US/XYZ.xml
@@ -26,8 +26,8 @@
 					Use this format in backticks when referring to architecture as a value or parameter. 
 				</para>
 				 <para>
-					Cloud providers can use different formats of this term when using architectures. 
-					If you are documenting code, commands or outputs, confer with your subject-matter expert on the correct format for the specific use case.
+					Cloud providers might use different formats of this term to refer to architectures. 
+					If you are documenting code, commands or outputs, then confer with your subject-matter expert on the correct format for the specific use case.
 				</para>
 				 <para>
 					Examples:


### PR DESCRIPTION
Implementing the formal documented guidance for these related terms, as approved by Word Nerds.