### PR TITLE
Footnote update

### DIFF
--- a/en-US/Design.xml
+++ b/en-US/Design.xml
@@ -1419,7 +1419,7 @@ Publication Title by First name Surname; Publisher.
 			 <listitem>
 				<para>
 					If the URL is excessively long or complex, create a link by using the title of the destination as a label, and put the actual URL in a footnote. For example: Refer to the <ulink url="http://world-database-of-everything.com/en/classifcation_of_species/mammals.html"><citetitle>Classification of Species</citetitle></ulink><footnote> <para>
-						http://world-database-of-everything.com/en/classifcation_of_species/mammals.html
+						<ulink url="http://world-database-of-everything.com/en/classifcation_of_species/mammals.html" />
 					</para>
 					 </footnote> page for more information.
 				</para>

--- a/en-US/Design.xml
+++ b/en-US/Design.xml
@@ -1418,8 +1418,9 @@ Publication Title by First name Surname; Publisher.
 			</listitem>
 			 <listitem>
 				<para>
-					If the URL is excessively long or complex, create a link by using the title of the destination as a label, and put the actual URL in a footnote. For example: Refer to the <ulink url="http://world-database-of-everything.com/en/classifcation_of_species/mammals.html"><citetitle>Classification of Species</citetitle></ulink><footnote> <para>
-						<ulink url="http://world-database-of-everything.com/en/classifcation_of_species/mammals.html" />
+					If the URL is long or complex, then create a link by using the title of the destination as a label, and put the URL in a footnote. 
+					For example: Refer to the <ulink url="https://www.britannica.com/animal/mammal/Classification"><citetitle>Classification of Species</citetitle></ulink><footnote> <para>
+						<ulink url="https://www.britannica.com/animal/mammal/Classification" />
 					</para>
 					 </footnote> page for more information.
 				</para>


### PR DESCRIPTION
I have added `ulink` tag to a URL footnote.
Changing color for a non-URL footnote requires css update.
We can do this by updating configuration file for site building tool.

**Before**
LightMode
![image](https://github.com/StyleGuides/WritingStyleGuide/assets/52556240/6c5293e3-befd-4805-b9c6-7b1090d1e540)
DarkMode
![image](https://github.com/StyleGuides/WritingStyleGuide/assets/52556240/4776d875-1298-4703-a252-2227aa5844fe)


**After**
LightMode
![image](https://github.com/StyleGuides/WritingStyleGuide/assets/52556240/68b04c9a-c139-4121-be5f-ed1039452396)
DarkMode
![image](https://github.com/StyleGuides/WritingStyleGuide/assets/52556240/205b457f-a871-456e-8123-3d90336f615c)
