### PR TITLE
Add gitignore for untracked files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,12 @@
+*~
+.DS_Store
+.idea
+
+# editor swap files
+.*.sw?
+
+# databases
+*.db
+
+# tmp directory
+tmp


### PR DESCRIPTION
To help keep untracked files and directories out of the repository, I've recommended a baseline `.gitignore` file. This allows directories like `tmp` and any SQLite database files—which I usually see in `en-US` depending on the build format—to remain even as updates are pushed.

This has been tested by running `publican build --langs=en-US` using each format in turn. Happy to have others verify as well. Thanks!