### PR TITLE
Remove yes/no as values for Ansible 'become'

### DIFF
--- a/en-US/Design.xml
+++ b/en-US/Design.xml
@@ -642,7 +642,7 @@ STEP 14: COMMIT <emphasis>...output omitted...</emphasis> localhost/nexus:latest
           </listitem>
           <listitem>
             <para>
-              If most tasks in a play require escalated privileges, set the entire play to <varname>become: true</varname> and selectively set individual tasks that do not need escalated privileges to <varname>become: false</varname>.
+              If most tasks in a play require escalated privileges, then set the entire play to <varname>become: true</varname> and selectively set individual tasks that do not need escalated privileges to <varname>become: false</varname>.
             </para>
           </listitem>
         </itemizedlist>

--- a/en-US/Design.xml
+++ b/en-US/Design.xml
@@ -637,12 +637,12 @@ STEP 14: COMMIT <emphasis>...output omitted...</emphasis> localhost/nexus:latest
           </listitem>
           <listitem>
             <para>
-              As much as possible, leave the system-wide default as <varname>become: false</varname> or <varname>become: no</varname> and if a single task needs privileges, set <varname>become: true</varname> or <varname>become: yes</varname> on that task.
+              As much as possible, leave the system-wide default as <varname>become: false</varname> and if a single task needs privileges, set <varname>become: true</varname> on that task.
             </para>
           </listitem>
           <listitem>
             <para>
-              If most tasks in a play require escalated privileges, set the entire play to <varname>become: true</varname> or <varname>become: yes</varname> and possibly selectively set individual tasks to <varname>become: false</varname> or <varname>become: no</varname>.
+              If most tasks in a play require escalated privileges, set the entire play to <varname>become: true</varname> and possibly selectively set individual tasks to <varname>become: false</varname>.
             </para>
           </listitem>
         </itemizedlist>

--- a/en-US/Design.xml
+++ b/en-US/Design.xml
@@ -637,7 +637,8 @@ STEP 14: COMMIT <emphasis>...output omitted...</emphasis> localhost/nexus:latest
           </listitem>
           <listitem>
             <para>
-              As much as possible, configure the default setting for <varname>become</varname> to <code>false</code>. If a single task needs privileges, then set <varname>become: true</varname> on that task.
+              As much as possible, configure the default setting for <varname>become</varname> to <code>false</code>.
+			  If a single task needs privileges, then set <varname>become: true</varname> on that task.
             </para>
           </listitem>
           <listitem>

--- a/en-US/Design.xml
+++ b/en-US/Design.xml
@@ -637,7 +637,7 @@ STEP 14: COMMIT <emphasis>...output omitted...</emphasis> localhost/nexus:latest
           </listitem>
           <listitem>
             <para>
-              As much as possible, configure the default setting for <varname>become</varname> to <code>false</code>, and if a single task needs privileges, set <varname>become: true</varname> on that task.
+              As much as possible, configure the default setting for <varname>become</varname> to <code>false</code>. If a single task needs privileges, then set <varname>become: true</varname> on that task.
             </para>
           </listitem>
           <listitem>

--- a/en-US/Design.xml
+++ b/en-US/Design.xml
@@ -637,12 +637,12 @@ STEP 14: COMMIT <emphasis>...output omitted...</emphasis> localhost/nexus:latest
           </listitem>
           <listitem>
             <para>
-              As much as possible, leave the system-wide default as <varname>become: false</varname> and if a single task needs privileges, set <varname>become: true</varname> on that task.
+              As much as possible, configure the default setting for <varname>become</varname> to <code>false</code>, and if a single task needs privileges, set <varname>become: true</varname> on that task.
             </para>
           </listitem>
           <listitem>
             <para>
-              If most tasks in a play require escalated privileges, set the entire play to <varname>become: true</varname> and possibly selectively set individual tasks to <varname>become: false</varname>.
+              If most tasks in a play require escalated privileges, set the entire play to <varname>become: true</varname> and selectively set individual tasks that do not need escalated privileges to <varname>become: false</varname>.
             </para>
           </listitem>
         </itemizedlist>


### PR DESCRIPTION
Remove the "yes" and "no" options for `become` in Ansible Playbooks and YAML files, preferring only the "true" and "false" options for Booleans.  This is the recommended practice based on *ansible-lint* rules and Ansible BU input.