### PR TITLE
Fix CD to refer to continuous deployment

### DIFF
--- a/en-US/C.xml
+++ b/en-US/C.xml
@@ -150,7 +150,7 @@
 			<term>CI/CD</term>
 			 <listitem>
 				<para>
-					Define on first use; generally continuous integration/continuous delivery. It does not mean continuous development, a term with questionable usefulness and only marginal adoption.
+					Define on first use; generally continuous integration/continuous delivery or deployment. It does not mean continuous development, a term with questionable usefulness and only marginal adoption.
 				</para>
 				 <para>
 					Refer also to <xref linkend="continuous-integration" />, <xref linkend="continuous-delivery" />, <xref linkend="continuous-deployment" />.

--- a/en-US/C.xml
+++ b/en-US/C.xml
@@ -457,7 +457,7 @@
 			<term>continuous deployment</term>
 			 <listitem>
 				<para>
-					A special case of continuous delivery, where approved code is automatically pushed to production. Do not use "CD" to refer to this practice.
+					A special case of continuous delivery, where approved code is automatically pushed to production.
 				</para>
 
 			</listitem>


### PR DESCRIPTION
It seems there is an inaccurate (or mistake) information around `CICD` and `continuous deployment` terms.

First you have the following sentence:

```
CI/CD
    Define on first use; generally continuous integration/continuous delivery. It does not mean continuous development, a term with questionable usefulness and only marginal adoption.
``` 
 The last sentence is correct because apply to CONTINUOUS DEVELOPMENT and not continuous DEPLOYMENT, which is also an option for CD. CD can be either continuous delivery/deployment.
 
 The other sentence:
 
```
continuous deployment
    A special case of continuous delivery, where approved code is automatically pushed to production. Do not use "CD" to refer to this practice. 
```
The last sentence about "Do not use CD to refer to this practice" is not correct. It would be correct for Continuous Development, but not for continuous deployment.

You can see that CD refers to continuous delivery/deployment in the industry, you can check some examples from our own articles, and also for the DO400 course:
- https://www.redhat.com/en/topics/devops/what-is-ci-cd
- https://www.redhat.com/en/resources/ansible-automation-platform-ci-cd-overview
- https://developers.redhat.com/articles/2023/02/28/how-employ-continuous-deployment-ansible-openshift#how_to_install_ansible_automation_platform_in_openshift
- https://rol-factory.ole.redhat.com/rol/app/courses/do400-4.12/pages/ch01

 
 

