### PR TITLE
docs: remove dead random-name-generator link

### DIFF
--- a/en-US/Design.xml
+++ b/en-US/Design.xml
@@ -879,13 +879,6 @@ telemetry-operator.v1.0.0               Telemetry Operator             ... -->
 						</para>
 
 					</listitem>
-					 <listitem>
-						<para>
-							<ulink url="http://random-name-generator.info/">http://random-name-generator.info/</ulink>
-						</para>
-
-					</listitem>
-
 				</itemizedlist>
 				 <formalpara id="using-extended-group-names">
 					<title>Group Names</title>


### PR DESCRIPTION
## Summary
- remove the dead `http://random-name-generator.info/` entry from the “Sourcing Realistic Names” list in `en-US/Design.xml`

## Why
The linked site is no longer available, so removing it prevents readers from hitting a broken resource while keeping the other name-generator references intact.

Closes #676
